### PR TITLE
Auth view redesigns

### DIFF
--- a/app/Http/Controllers/ShowDashboard.php
+++ b/app/Http/Controllers/ShowDashboard.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class ShowDashboard extends Controller
+{
+    /**
+     * Handle the incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function __invoke(Request $request)
+    {
+        if( Auth::id() )
+        {
+            $user = User::findOrFail( Auth::id() );
+            return view('dashboard.index')->with('user', $user);
+        }
+
+        return view( '/welcome' );
+    }
+}

--- a/app/Http/Middleware/Admin.php
+++ b/app/Http/Middleware/Admin.php
@@ -28,6 +28,6 @@ class Admin
             return $next($request);
         }
 
-        return redirect()->route( 'login' )->with( 'error', 'Access denied, login to continue.' );
+        return redirect()->route( 'login-form' )->with( 'error', 'Aja baja, du saknar rättigheterna för det där, logga in för att fortsätta.' );
     }
 }

--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -15,7 +15,7 @@ class Authenticate extends Middleware
     protected function redirectTo($request)
     {
         if (! $request->expectsJson()) {
-            return route('login');
+            return route('login-form');
         }
     }
 }

--- a/app/Http/Middleware/Moderator.php
+++ b/app/Http/Middleware/Moderator.php
@@ -17,7 +17,7 @@ class Moderator
     {
         $this->auth = auth()->user() ? (
             auth()->user()->role === 'moderator' ||
-            auth()->user()->role === 'admin' || 
+            auth()->user()->role === 'admin' ||
             auth()->user()->role === 'super' ) : false ;
 
         if( $this->auth === true )
@@ -25,6 +25,6 @@ class Moderator
             return $next($request);
         }
 
-        return redirect()->route( 'login' )->with( 'error', 'Access denied, login to continue.' );
+        return redirect()->route( 'login-form' )->with( 'error', 'Aja baja, du saknar rättigheterna för det där, logga in för att fortsätta.' );
     }
 }

--- a/app/Http/Middleware/Super.php
+++ b/app/Http/Middleware/Super.php
@@ -20,11 +20,12 @@ class Super
     {
         $this->auth = auth()->user() ? ( auth()->user()->role === 'super' ) : false ;
 
-        if( $this->auth === true )
+        if( $this->auth )
         {
-            return $next($request);
+            return $next( $request );
         }
 
-        return redirect()->route( 'login-form' )->with( 'error', 'Aja baja, du saknar rättigheterna för det där, logga in för att fortsätta.' );
+        return redirect()->route( 'login-form' )
+            ->with( 'error', 'Aja baja, du saknar rättigheterna för det där, logga in för att fortsätta.' );
     }
 }

--- a/app/Http/Middleware/Super.php
+++ b/app/Http/Middleware/Super.php
@@ -25,6 +25,6 @@ class Super
             return $next($request);
         }
 
-        return redirect()->route( 'login' )->with( 'error', 'Access denied, login to continue.' );
+        return redirect()->route( 'login-form' )->with( 'error', 'Aja baja, du saknar rättigheterna för det där, logga in för att fortsätta.' );
     }
 }

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1,2 +1,6 @@
-@import url(https://fonts.googleapis.com/css?family=Nunito);
+@import url(https://fonts.googleapis.com/css?family=Nunito);.is-fullwidth {
+  min-width: 100vw;
+  margin-left: -33.33%;
+  margin-right: -33.33%;
+}
 

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1,6 +1,25 @@
-@import url(https://fonts.googleapis.com/css?family=Nunito);.is-fullwidth {
+@import url(https://fonts.googleapis.com/css?family=Exo|Noto+Sans&display=swap);h1,
+h2,
+h3 {
+  font-family: "Exo", Arial, sans-serif;
+}
+
+p,
+a,
+button,
+input,
+label {
+  font-family: "Noto Sans", Arial, sans-serif;
+}
+
+.is-fullwidth {
   min-width: 100vw;
   margin-left: -33.33%;
   margin-right: -33.33%;
+  font-family: "Noto Sans", sans-serif;
+}
+
+.footer {
+  padding: 2.5rem;
 }
 

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -1,13 +1,11 @@
-// Fonts
-@import url('https://fonts.googleapis.com/css?family=Nunito');
+// Import partials
 
-// Variables
-@import 'variables';
+// General
+@import 'general/variables';
+@import 'general/colors';
+@import 'general/typography';
+@import 'general/layout';
 
-
-.is-fullwidth {
-    min-width: 100vw;
-    margin-left: -33.33%;
-    margin-right: -33.33%;
-    font-family: $font-family-sans-serif;
-}
+//Layout
+@import "layout/footer";
+@import "layout/navbar";

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -3,3 +3,11 @@
 
 // Variables
 @import 'variables';
+
+
+.is-fullwidth {
+    min-width: 100vw;
+    margin-left: -33.33%;
+    margin-right: -33.33%;
+    font-family: $font-family-sans-serif;
+}

--- a/resources/sass/general/_colors.scss
+++ b/resources/sass/general/_colors.scss
@@ -1,11 +1,3 @@
-// Body
-$body-bg: #f8fafc;
-
-// Typography
-$font-family-sans-serif: 'Nunito', sans-serif;
-$font-size-base: 0.9rem;
-$line-height-base: 1.6;
-
 // Colors
 $blue: #3490dc;
 $indigo: #6574cd;

--- a/resources/sass/general/_layout.scss
+++ b/resources/sass/general/_layout.scss
@@ -1,0 +1,7 @@
+
+.is-fullwidth {
+    min-width: 100vw;
+    margin-left: -33.33%;
+    margin-right: -33.33%;
+    font-family: $font-family-sans-serif;
+}

--- a/resources/sass/general/_typography.scss
+++ b/resources/sass/general/_typography.scss
@@ -1,0 +1,19 @@
+// Imports
+@import url('https://fonts.googleapis.com/css?family=Exo|Noto+Sans&display=swap');
+
+// Typography
+$font-family-sans-serif: 'Noto Sans', sans-serif;
+$header-font: 'Exo', Arial, sans-serif;
+$text-font: 'Noto Sans', Arial, sans-serif;
+$font-size-base: 0.9rem;
+$line-height-base: 1.6;
+
+h1, h2, h3
+{
+    font-family: $header-font;
+}
+
+p, a, button, input, label
+{
+    font-family: $text-font;
+}

--- a/resources/sass/general/_variables.scss
+++ b/resources/sass/general/_variables.scss
@@ -1,0 +1,2 @@
+// Body
+$body-bg: #f8fafc;

--- a/resources/sass/layout/footer.scss
+++ b/resources/sass/layout/footer.scss
@@ -1,0 +1,4 @@
+.footer
+{
+    padding: 2.5rem;
+}

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,73 +1,62 @@
 @extends('layouts.app')
-
+@section( 'title', 'Logga in' )
 @section('content')
-<div class="container">
-    <div class="row justify-content-center">
-        <div class="col-md-8">
-            <div class="card">
-                <div class="card-header">{{ __('Login') }}</div>
 
-                <div class="card-body">
-                    <form method="POST" action="{{ route('login') }}">
-                        @csrf
-
-                        <div class="form-group row">
-                            <label for="email" class="col-md-4 col-form-label text-md-right">{{ __('E-Mail Address') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="email" type="email" class="form-control @error('email') is-invalid @enderror" name="email" value="{{ old('email') }}" required autocomplete="email" autofocus>
-
-                                @error('email')
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $message }}</strong>
-                                    </span>
-                                @enderror
-                            </div>
+    <section class="section">
+        <div class="columns level">
+            <div class="column is-half is-widescreen level-item">
+                <h1 class="title">Logga in</h1>
+                <p>Logga in för att komma åt all kakor. Ja, det finns kakor.</p>
+                <br>
+                <form method="POST" action="{{ route('login') }}">
+                    @csrf
+                    <div class="field">
+                        <label class="label">E-postadress</label>
+                        <div class="control">
+                            <input class="input @error( 'email' ) is-danger @enderror" type="email" placeholder="E-postadress" name="email" value="{{ old( 'email' ) }}" required autofocus>
+                            @error( 'email' )
+                                <span class="has-text-danger" role="alert">
+                                    {{ $message }}
+                                </span>
+                            @enderror
                         </div>
-
-                        <div class="form-group row">
-                            <label for="password" class="col-md-4 col-form-label text-md-right">{{ __('Password') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="password" type="password" class="form-control @error('password') is-invalid @enderror" name="password" required autocomplete="current-password">
-
-                                @error('password')
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $message }}</strong>
-                                    </span>
-                                @enderror
-                            </div>
+                    </div>
+                    <div class="field">
+                        <label class="label">Lösenord</label>
+                        <div class="control">
+                            <input class="input @error( 'password' ) is-danger @enderror" type="password" name="password" placeholder="Lösenord" required>
+                            @error( 'password' )
+                                <span class="has-text-danger" role="alert">
+                                    {{ $message }}
+                                </span>
+                            @enderror
                         </div>
-
-                        <div class="form-group row">
-                            <div class="col-md-6 offset-md-4">
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox" name="remember" id="remember" {{ old('remember') ? 'checked' : '' }}>
-
-                                    <label class="form-check-label" for="remember">
-                                        {{ __('Remember Me') }}
-                                    </label>
-                                </div>
-                            </div>
+                    </div>
+                    <div class="field">
+                        <div class="control">
+                            <label class="checkbox">
+                                <input type="checkbox">
+                                Kom ihåg mig!
+                            </label>
                         </div>
-
-                        <div class="form-group row mb-0">
-                            <div class="col-md-8 offset-md-4">
-                                <button type="submit" class="btn btn-primary">
-                                    {{ __('Login') }}
-                                </button>
-
-                                @if (Route::has('password.request'))
-                                    <a class="btn btn-link" href="{{ route('password.request') }}">
-                                        {{ __('Forgot Your Password?') }}
-                                    </a>
-                                @endif
-                            </div>
+                    </div>
+                    <div class="field is-grouped">
+                        <div class="control">
+                            <button class="button is-primary" type="submit">Logga in</button>
                         </div>
-                    </form>
-                </div>
+                        <div class="control">
+                            <button class="button is-light" href="{{ url()->previous() }}">Avbryt</button>
+                        </div>
+                    </div>
+                    <a class="is-link" href="{{ route( 'password.request' ) }}">Glömt ditt lösenord?</a>
+                </form>
+            </div>
+            <div class="column is-half is-widescreen level-item has-text-centered">
+                <figure class="image">
+                    <img src="https://via.placeholder.com/400x400.png/09f/fff" />
+                </figure>
             </div>
         </div>
-    </div>
-</div>
+    </section>
+
 @endsection

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -45,7 +45,7 @@
                             <button class="button is-primary" type="submit">Logga in</button>
                         </div>
                         <div class="control">
-                            <button class="button is-light" href="{{ url()->previous() }}">Avbryt</button>
+                            <a class="button is-light" href="{{ route( 'dashboard' )  }}">Avbryt</a>
                         </div>
                     </div>
                     <a class="is-link" href="{{ route( 'password.request' ) }}">Glömt ditt lösenord?</a>

--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -1,47 +1,43 @@
 @extends('layouts.app')
-
+@section( 'title', 'Glömt ditt lösenord?' )
 @section('content')
-<div class="container">
-    <div class="row justify-content-center">
-        <div class="col-md-8">
-            <div class="card">
-                <div class="card-header">{{ __('Reset Password') }}</div>
 
-                <div class="card-body">
-                    @if (session('status'))
-                        <div class="alert alert-success" role="alert">
-                            {{ session('status') }}
+    <section class="section">
+        <div class="columns level">
+            <div class="column is-half is-widescreen level-item">
+                <h1 class="title">Glömt ditt lösenord?</h1>
+                <p>Det är okej, det händer alla ibland. Här kan du återställa ditt lösenord.</p>
+                <br>
+                <form method="POST" action="{{ route('password.email') }}">
+                    @csrf
+                    <div class="field">
+                        <label class="label">E-postadress</label>
+                        <div class="control">
+                            <input class="input @error( 'email' ) is-danger @enderror" type="email" placeholder="E-postadress" name="email" value="{{ old( 'email' ) }}">
+                            @error( 'email' )
+                            <span class="has-text-danger" role="alert">
+                                    {{ $message }}
+                                </span>
+                            @enderror
                         </div>
-                    @endif
-
-                    <form method="POST" action="{{ route('password.email') }}">
-                        @csrf
-
-                        <div class="form-group row">
-                            <label for="email" class="col-md-4 col-form-label text-md-right">{{ __('E-Mail Address') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="email" type="email" class="form-control @error('email') is-invalid @enderror" name="email" value="{{ old('email') }}" required autocomplete="email" autofocus>
-
-                                @error('email')
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $message }}</strong>
-                                    </span>
-                                @enderror
-                            </div>
+                    </div>
+                    <div class="field is-grouped">
+                        <div class="control">
+                            <button class="button is-primary" type="submit">Skicka</button>
                         </div>
-
-                        <div class="form-group row mb-0">
-                            <div class="col-md-6 offset-md-4">
-                                <button type="submit" class="btn btn-primary">
-                                    {{ __('Send Password Reset Link') }}
-                                </button>
-                            </div>
+                        <div class="control">
+                            <button class="button is-light" href="{{ url()->previous() }}">Avbryt</button>
                         </div>
-                    </form>
-                </div>
+                    </div>
+                    <a class="is-link" href="{{ route( 'login-form' ) }}">Logga in istället?</a>
+                </form>
+            </div>
+            <div class="column is-half is-widescreen level-item has-text-centered">
+                <figure class="image">
+                    <img src="https://via.placeholder.com/400x400.png/09f/fff" />
+                </figure>
             </div>
         </div>
-    </div>
-</div>
+    </section>
+
 @endsection

--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -15,7 +15,7 @@
                         <div class="control">
                             <input class="input @error( 'email' ) is-danger @enderror" type="email" placeholder="E-postadress" name="email" value="{{ old( 'email' ) }}">
                             @error( 'email' )
-                            <span class="has-text-danger" role="alert">
+                                <span class="has-text-danger" role="alert">
                                     {{ $message }}
                                 </span>
                             @enderror

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -17,7 +17,7 @@
                             <input placeholder="E-postadress" id="email" type="email" class="input @error( 'email' ) is-danger @enderror" name="email" value="{{ $email ?? old( 'email' ) }}" required autocomplete="email" autofocus>
                         </div>
                         @error( 'email' )
-                        <span class="has-text-danger" role="alert">
+                            <span class="has-text-danger" role="alert">
                                     {{ $message }}
                                 </span>
                         @enderror
@@ -27,7 +27,7 @@
                         <div class="control">
                             <input class="input @error( 'password' ) is-danger @enderror" name="password" type="password" placeholder="Lösenord" required>
                             @error( 'password' )
-                            <span class="has-text-danger" role="alert">
+                                <span class="has-text-danger" role="alert">
                                     {{ $message }}
                                 </span>
                             @enderror
@@ -38,7 +38,7 @@
                         <div class="control">
                             <input class="input @error( 'password-confirm' ) is-danger @enderror" name="password-confirm" type="password" placeholder="Lösenord" required>
                             @error( 'password-confirm' )
-                            <span class="has-text-danger" role="alert">
+                                <span class="has-text-danger" role="alert">
                                     {{ $message }}
                                 </span>
                             @enderror

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -1,65 +1,65 @@
 @extends('layouts.app')
-
+@section( 'title', 'Återställ ditt lösenord här' )
 @section('content')
-<div class="container">
-    <div class="row justify-content-center">
-        <div class="col-md-8">
-            <div class="card">
-                <div class="card-header">{{ __('Reset Password') }}</div>
 
-                <div class="card-body">
-                    <form method="POST" action="{{ route('password.update') }}">
-                        @csrf
-
-                        <input type="hidden" name="token" value="{{ $token }}">
-
-                        <div class="form-group row">
-                            <label for="email" class="col-md-4 col-form-label text-md-right">{{ __('E-Mail Address') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="email" type="email" class="form-control @error('email') is-invalid @enderror" name="email" value="{{ $email ?? old('email') }}" required autocomplete="email" autofocus>
-
-                                @error('email')
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $message }}</strong>
-                                    </span>
-                                @enderror
-                            </div>
+    <section class="section">
+        <div class="columns level">
+            <div class="column is-half is-widescreen level-item">
+                <h1 class="title">Återställ ditt lösenord här</h1>
+                <p>Dags att återställa ditt lösenord, se till att komma ihåg det. :)</p>
+                <br>
+                <form method="POST" action="{{ route( 'password.update' ) }}">
+                    @csrf
+                    <input type="hidden" name="token" value="{{ $token }}">
+                    <div class="field">
+                        <label class="label">E-postadress</label>
+                        <div class="control">
+                            <input placeholder="E-postadress" id="email" type="email" class="input @error( 'email' ) is-danger @enderror" name="email" value="{{ $email ?? old( 'email' ) }}" required autocomplete="email" autofocus>
                         </div>
-
-                        <div class="form-group row">
-                            <label for="password" class="col-md-4 col-form-label text-md-right">{{ __('Password') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="password" type="password" class="form-control @error('password') is-invalid @enderror" name="password" required autocomplete="new-password">
-
-                                @error('password')
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $message }}</strong>
-                                    </span>
-                                @enderror
-                            </div>
+                        @error( 'email' )
+                        <span class="has-text-danger" role="alert">
+                                    {{ $message }}
+                                </span>
+                        @enderror
+                    </div>
+                    <div class="field">
+                        <label class="label">Lösenord</label>
+                        <div class="control">
+                            <input class="input @error( 'password' ) is-danger @enderror" name="password" type="password" placeholder="Lösenord" required>
+                            @error( 'password' )
+                            <span class="has-text-danger" role="alert">
+                                    {{ $message }}
+                                </span>
+                            @enderror
                         </div>
-
-                        <div class="form-group row">
-                            <label for="password-confirm" class="col-md-4 col-form-label text-md-right">{{ __('Confirm Password') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="password-confirm" type="password" class="form-control" name="password_confirmation" required autocomplete="new-password">
-                            </div>
+                    </div>
+                    <div class="field">
+                        <label class="label">Verifiera lösenordet</label>
+                        <div class="control">
+                            <input class="input @error( 'password-confirm' ) is-danger @enderror" name="password-confirm" type="password" placeholder="Lösenord" required>
+                            @error( 'password-confirm' )
+                            <span class="has-text-danger" role="alert">
+                                    {{ $message }}
+                                </span>
+                            @enderror
                         </div>
-
-                        <div class="form-group row mb-0">
-                            <div class="col-md-6 offset-md-4">
-                                <button type="submit" class="btn btn-primary">
-                                    {{ __('Reset Password') }}
-                                </button>
-                            </div>
+                    </div>
+                    <div class="field is-grouped">
+                        <div class="control">
+                            <button class="button is-primary" type="submit">Återställ lösenordet</button>
                         </div>
-                    </form>
-                </div>
+                        <div class="control">
+                            <button class="button is-light" href="{{ '/' }}">Avbryt</button>
+                        </div>
+                    </div>
+                </form>
+            </div>
+            <div class="column is-half is-widescreen level-item has-text-centered">
+                <figure class="image">
+                    <img src="https://via.placeholder.com/400x400.png/09f/fff" />
+                </figure>
             </div>
         </div>
-    </div>
-</div>
+    </section>
+
 @endsection

--- a/resources/views/auth/verify.blade.php
+++ b/resources/views/auth/verify.blade.php
@@ -1,28 +1,32 @@
 @extends('layouts.app')
 
 @section('content')
-<div class="container">
-    <div class="row justify-content-center">
-        <div class="col-md-8">
-            <div class="card">
-                <div class="card-header">{{ __('Verify Your Email Address') }}</div>
 
-                <div class="card-body">
-                    @if (session('resent'))
-                        <div class="alert alert-success" role="alert">
-                            {{ __('A fresh verification link has been sent to your email address.') }}
-                        </div>
-                    @endif
-
-                    {{ __('Before proceeding, please check your email for a verification link.') }}
-                    {{ __('If you did not receive the email') }},
-                    <form class="d-inline" method="POST" action="{{ route('verification.resend') }}">
-                        @csrf
-		                <button type="submit" class="btn btn-link p-0 m-0 align-baseline">{{ __('click here to request another') }}</button>.
-	                </form>
-                </div>
+    <section class="section">
+        <div class="columns level">
+            <div class="column is-half is-widescreen level-item">
+                <h1 class="title">Verifiera din e-postadress här</h1>
+                <p>
+                    För att vi ska kunna veta att det är du, så behöver du verifiera din e-postadress!
+                    Kolla i din inkorg så kan vi vara säkra på att det är du.
+                    <br>
+                    <br>
+                    Fick du inget mail?
+                    <br>
+                    Klicka nedan för att skicka ett nytt verifieringsmail.
+                </p>
+                <br>
+                <form>
+                    @csrf
+                    <button type="submit" class="button is-primary">Skicka igen</button>
+                </form>
+            </div>
+            <div class="column is-half is-widescreen level-item has-text-centered">
+                <figure class="image">
+                    <img src="https://via.placeholder.com/400x400.png/09f/fff" />
+                </figure>
             </div>
         </div>
-    </div>
-</div>
+    </section>
+
 @endsection

--- a/resources/views/dashboard/index.blade.php
+++ b/resources/views/dashboard/index.blade.php
@@ -1,7 +1,6 @@
-@section('title', 'Startsida')
-@extends('layouts.app')
-
-@section('content')
+@extends( 'layouts.app' )
+@section( 'title', Auth::user()->name )
+@section( 'content' )
 
     <section class="hero is-primary is-fullwidth has-text-centered">
         <div class="hero-body">
@@ -13,23 +12,18 @@
     </section>
 
     <section class="section">
-        <div class="columns level">
-            <div class="column is-half is-widescreen level-item">
-                <h2 class="title is-3">Vad vill du göra idag?</h2>
-                <h3 class="subtitle is-5">Välj ett alternativ nedan:</h3>
-                <div class="buttons">
+        <div class="columns is-centered">
+            <div class="column is-half is-widescreen has-text-centered">
+                <h1 class="title">Vad vill du göra idag?</h1>
+                <h2 class="subtitle">Välj ett alternativ nedan:</h2>
+                <p>Din roll: {{ $user->role  }}</p>
+                <div class="buttons is-centered">
                     <a class="button is-primary">Saker</a>
                     <a class="button is-primary">Saker</a>
                     <a class="button is-primary">Saker</a>
                 </div>
             </div>
-            <div class="column is-half is-widescreen level-item">
-                <figure class="image">
-                    <img src="https://via.placeholder.com/400x400.png/09f/fff" />
-                </figure>
-            </div>
         </div>
     </section>
-
 
 @endsection

--- a/resources/views/dashboard/index.blade.php
+++ b/resources/views/dashboard/index.blade.php
@@ -1,0 +1,35 @@
+@section('title', 'Startsida')
+@extends('layouts.app')
+
+@section('content')
+
+    <section class="hero is-primary is-fullwidth has-text-centered">
+        <div class="hero-body">
+            <div class="container">
+                <h1 class="title">Hejsan, {{ Auth::user()->name }}</h1>
+                <h3 class="subtitle">Välkommen tillbaka!</h3>
+            </div>
+        </div>
+    </section>
+
+    <section class="section">
+        <div class="columns level">
+            <div class="column is-half is-widescreen level-item">
+                <h2 class="title is-3">Vad vill du göra idag?</h2>
+                <h3 class="subtitle is-5">Välj ett alternativ nedan:</h3>
+                <div class="buttons">
+                    <a class="button is-primary">Saker</a>
+                    <a class="button is-primary">Saker</a>
+                    <a class="button is-primary">Saker</a>
+                </div>
+            </div>
+            <div class="column is-half is-widescreen level-item">
+                <figure class="image">
+                    <img src="https://via.placeholder.com/400x400.png/09f/fff" />
+                </figure>
+            </div>
+        </div>
+    </section>
+
+
+@endsection

--- a/resources/views/layouts/partials/flash-messages.blade.php
+++ b/resources/views/layouts/partials/flash-messages.blade.php
@@ -11,3 +11,10 @@
         {{ session()->get( 'error' ) }}
     </div>
 @endif
+
+@if( session( 'resent' ) )
+    <div class="notification is-info">
+        <button class="delete"></button>
+        Ett nytt verifieringsmail har skickats till din e-postadress.
+    </div>
+@endif

--- a/resources/views/layouts/partials/head.blade.php
+++ b/resources/views/layouts/partials/head.blade.php
@@ -11,12 +11,12 @@
 <link href="https://fonts.googleapis.com/css?family=Nunito" rel="stylesheet">
 <link href="https://cdn.jsdelivr.net/npm/cookieconsent@3/build/cookieconsent.min.css" rel="stylesheet" type="text/css">
 <link href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.5/css/bulma.min.css" rel="stylesheet" type="text/css">
-<link href="{{ asset('css/app.css') }}" rel="stylesheet">
+<link href="{{ mix('css/app.css') }}" rel="stylesheet">
 
 <!-- Scripts -->
 <script defer src="https://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
 <script defer src="https://use.fontawesome.com/releases/v5.3.1/js/all.js"></script>
-<script defer src="{{ asset('js/app.js') }}"></script>
+<script defer src="{{ mix('js/app.js') }}"></script>
 
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script defer src="https://www.googletagmanager.com/gtag/js?id=UA-136489552-2"></script>

--- a/resources/views/layouts/partials/navbar.blade.php
+++ b/resources/views/layouts/partials/navbar.blade.php
@@ -13,6 +13,9 @@
 
     <div id="navbarMain" class="navbar-menu">
         <div class="navbar-start">
+            <a href="{{ route( 'dashboard' ) }}" class="navbar-item">
+                {{ env( 'APP_NAME' )  }}
+            </a>
             {{-- Left side of the navbar --}}
             <a class="navbar-item" href="{{ route( 'linda' ) }}">
                 Linda

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -3,22 +3,25 @@
 
 @section('content')
 
-    <h1>{{ $user->name }} - {{ $user->role }}</h1>
-    <h3>{{ $user->email }}</h3>
-    <p>Välkommen tillbaka!</p>
+    <section class="hero is-primary is-fullwidth has-text-centered">
+        <div class="hero-body">
+            <div class="container">
+                <h1 class="title">Hejsan, {{ $user->name }}</h1>
+                <h3 class="subtitle">Här är din profil, ta en titt!</h3>
+            </div>
+        </div>
+    </section>
 
-    <ul>
-        <li>Förening: {{ $user->association->name }}</li>
-        <li>Universitet: {{ $user->association->university->name }}</li>
-    </ul>
-    <hr>
-    <h4>Kurser: {{ $user->association->courses->count() }}</h4>
-    <h4>Tentor: {{ $user->association->exams->count() }}</h4>
-
-    @if( $user->role == 'super'  )
-
-
-
-    @endif
+    <section class="section">
+        <h4 class="title is-3">Förening: {{ $user->association->name }}</h4>
+        <h4 class="subtitle is-5">Tillhör universitet: {{ $user->association->university->name }}</h4>
+        <p><b>Statistik om din föreing:</b></p>
+        <p>Kurser: {{ $user->association->courses->count() }}</p>
+        <p>Tentor: {{ $user->association->exams->count() }}</p>
+        <hr>
+        <h2 class="title is-3">Redigera din profil</h2>
+        <p>Vill du redigera din profil, klicka nedan.</p>
+        <a class="button is-primary" href="{{ route( 'profile.settings' ) }}">Inställningar</a>
+    </section>
 
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -59,6 +59,11 @@ Route::group( [ 'middleware' => 'verified' ], function()
 
     Route::group( [ 'middleware' => 'valid_user' ], function()
     {
+        Route::get( '/', function()
+        {
+           return view( 'dashboard.index' );
+        } )->name( 'dashboard' );
+
         Route::get( 'profil', 'UserController@index' )->name( 'profile' );
 
         Route::group( [ 'middleware' => [ 'moderator' ] ], function()

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,6 +10,9 @@
 | contains the "web" middleware group. Now create something great!
 |
 */
+
+Route::get( '/', 'ShowDashboard' )->name( 'dashboard' );
+
 // Authentication Routes...
 Route::get('logga-in', 'Auth\LoginController@showLoginForm')->name('login-form');
 Route::post('login', 'Auth\LoginController@login')->name( 'login' );
@@ -26,25 +29,20 @@ Route::get('email/verifiera', 'Auth\VerificationController@show')->name('verific
 Route::get('email/verifiera/{id}/{hash}', 'Auth\VerificationController@verify')->name('verification.verify'); // v6.x
 Route::get('email/skicka-igen', 'Auth\VerificationController@resend')->name('verification.resend');
 
-Route::get('/', function () {
-    return view('welcome');
-});
-
 Route::get( 'kontakt', function()
 {
-    return view( 'contacts/info' );
+    return view( 'contacts.info' );
 } )->name( 'contacts.info' );
 
 Route::get( 'support/kontakt', function()
 {
-    return view( 'contacts/support' );
+    return view( 'contacts.support' );
 } )->name( 'contacts.support' );
 
 Route::get( 'integritetspolicy', function()
 {
     return view( 'policy' );
 } )->name( 'policy' );
-
 
 Route::post( '/contact', 'SendContactRequest' );
 
@@ -59,11 +57,6 @@ Route::group( [ 'middleware' => 'verified' ], function()
 
     Route::group( [ 'middleware' => 'valid_user' ], function()
     {
-        Route::get( '/', function()
-        {
-           return view( 'dashboard.index' );
-        } )->name( 'dashboard' );
-
         Route::get( 'profil', 'UserController@index' )->name( 'profile' );
 
         Route::group( [ 'middleware' => [ 'moderator' ] ], function()


### PR DESCRIPTION
Redesigns authenticating view.

---

Auth views:
- Login
- Sign up
- Password reset 
- Email confirmation
- Resend password

Additions:
- New font (see commit [8dca8a6](https://github.com/Linda-Carlstad/tentahub.se/commit/8dca8a67482463aadcfaf881bf2d6d89f37092be))
- Multiple landing view, one for guest and one for logged in users
- Lots of SCSS files and folder

---

Fixes #18 
Fixes #24